### PR TITLE
(fix) compatibility with gedit >= 44

### DIFF
--- a/focus_autosave.py
+++ b/focus_autosave.py
@@ -4,7 +4,7 @@
 # Save document when losing focus.
 # Gautier Portet <kassoulet gmail.com>
 
-from gi.repository import GObject, Gtk, Gdk, Gedit, Gio
+from gi.repository import GObject, Gedit, Gio
 import datetime
 import os
 
@@ -33,7 +33,7 @@ class FocusAutoSavePlugin(GObject.Object, Gedit.WindowActivatable):
             if doc.get_file().is_readonly():
                 # skip read-only files
                 continue
-            if doc.is_untitled():
+            if doc.get_file().get_location() is None:
                 # provide a default filename
                 now = datetime.datetime.now()
                 assure_path_exists(dirname)


### PR DESCRIPTION
The `gedit_document_is_untitled()` function has been removed since `gedit 44` as mentioned [here](https://gedit-technology.net/developer-docs/gedit/api-breaks.html).

This PR fixes this issue and now the plugin works like a charm again.