### PR TITLE
Prevent saving in `.gedit_unsaved` when Ctrl+S is pressed!

### DIFF
--- a/focus_autosave.py
+++ b/focus_autosave.py
@@ -6,11 +6,18 @@
 
 import datetime
 
-from gi.repository import GObject, Gedit, Gio
+from gi.repository import GObject, Gedit, Gio, Gdk
 from pathlib import Path
+
+def on_key_press(widget, event):
+  global Ctrl_S
+  if event.state == Gdk.ModifierType.CONTROL_MASK and event.keyval == Gdk.KEY_s:
+      Ctrl_S = True
 
 # You can change here the default folder for unsaved files.
 dirname = Path("~/.gedit_unsaved/").expanduser()
+
+Ctrl_S = False
 
 class FocusAutoSavePlugin(GObject.Object, Gedit.WindowActivatable):
     __gtype_name__ = "FocusAutoSavePlugin"
@@ -20,6 +27,11 @@ class FocusAutoSavePlugin(GObject.Object, Gedit.WindowActivatable):
         GObject.Object.__init__(self)
 
     def on_focus_out_event(self, widget, focus):
+        global Ctrl_S
+        if Ctrl_S:
+            # skip to user specified file name
+            Ctrl_S = False
+            return
         for n, doc in enumerate(self.window.get_unsaved_documents()):
             if doc.is_untouched():
                 # nothing to do
@@ -38,10 +50,12 @@ class FocusAutoSavePlugin(GObject.Object, Gedit.WindowActivatable):
 
     def do_activate(self):
         self.signal = self.window.connect("focus-out-event", self.on_focus_out_event)
+        self.ctrl_s = self.window.connect("key-press-event", on_key_press)
 
     def do_deactivate(self):
         self.window.disconnect(self.signal)
-        del self.signal
+        self.window.disconnect(self.ctrl_s)
+        del self.signal, self.ctrl_s
 
 
 

--- a/focus_autosave.py
+++ b/focus_autosave.py
@@ -4,19 +4,13 @@
 # Save document when losing focus.
 # Gautier Portet <kassoulet gmail.com>
 
-from gi.repository import GObject, Gedit, Gio
 import datetime
-import os
+
+from gi.repository import GObject, Gedit, Gio
+from pathlib import Path
 
 # You can change here the default folder for unsaved files.
-dirname = os.path.expanduser("~/.gedit_unsaved/")
-
-
-def assure_path_exists(path):
-    dir = os.path.dirname(path)
-    if not os.path.exists(dir):
-            os.makedirs(dir)
-
+dirname = Path("~/.gedit_unsaved/").expanduser()
 
 class FocusAutoSavePlugin(GObject.Object, Gedit.WindowActivatable):
     __gtype_name__ = "FocusAutoSavePlugin"
@@ -36,8 +30,8 @@ class FocusAutoSavePlugin(GObject.Object, Gedit.WindowActivatable):
             if doc.get_file().get_location() is None:
                 # provide a default filename
                 now = datetime.datetime.now()
-                assure_path_exists(dirname)
-                filename = now.strftime(dirname + "%Y%m%d-%H%M%S-%%d.txt") % (n + 1)
+                Path(dirname).mkdir(parents=True, exist_ok=True)
+                filename = str(dirname/now.strftime(f"%Y%m%d-%H%M%S-{n+1}.txt"))
                 doc.get_file().set_location(Gio.file_parse_name(filename))
             # save the document
             Gedit.commands_save_document(self.window, doc)

--- a/makefile
+++ b/makefile
@@ -1,4 +1,7 @@
 
 install::
-	-mkdir -p ~/.local/share/gedit/plugins 
-	cp focus-autosave.plugin focus_autosave.py ~/.local/share/gedit/plugins
+	@mkdir -p ~/.local/share/gedit/plugins
+	@cp focus-autosave.plugin focus_autosave.py ~/.local/share/gedit/plugins -v
+
+uninstall:
+	@rm -fv  ~/.local/share/gedit/plugins/focus{-,_}autosave.{plugin,py}


### PR DESCRIPTION
In this PR, we have several features:

1. Added a new `Makefile` rule for `uninstall`.
2. Replaced `os` with `pathlib`.
3. Most importantly, prevented saving in the `~/.gedit_unsaved` directory when `Ctrl+S` is pressed!"