### PR TITLE
Preferences Window

### DIFF
--- a/focus-autosave.plugin
+++ b/focus-autosave.plugin
@@ -7,4 +7,4 @@ Description=Save all documents when losing focus.
 Authors=Gautier Portet <gautier@soundconverter.org>
 Copyright=Copyright © 2009-2023 Gautier Portet <gautier@soundconverter.org>
 Website=http://kassoulet.free.fr
-Version=3.0.2
+Version=3.1

--- a/focus_autosave.py
+++ b/focus_autosave.py
@@ -5,15 +5,37 @@
 # Gautier Portet <kassoulet gmail.com>
 
 import datetime
+import json
+import gi
 
-from gi.repository import GObject, Gedit, Gio, Gdk
+from gi.repository import GObject, Gedit, Gio, Gdk, Gtk, PeasGtk, GLib
+
 from pathlib import Path
 
-# You can change here the default folder for unsaved files.
-dirname = Path("~/.gedit_unsaved/").expanduser()
+gi.require_version("Gtk", "3.0")
+
+# region ############### CONSTANTs #################################
+DEFAULT_TEMP_PATH = "/tmp/.gedit_unsaved"
+
+GEDIT_CONFIG_DIR = Path(GLib.get_user_config_dir())/"gedit"
+COFING_FILE = Path(GEDIT_CONFIG_DIR)/"focus_autosave_settings.json"
+
+try:
+    with open(COFING_FILE, encoding="utf-8") as conf:
+        data = conf.read()
+    FA_CONFIG = json.loads(data)
+except (FileNotFoundError, json.JSONDecodeError):
+    FA_CONFIG = dict(temp_path=None)
+
+if FA_CONFIG["temp_path"] is not None:
+    TEMP_DIR = Path(FA_CONFIG.get("temp_path", DEFAULT_TEMP_PATH)).expanduser()
+    Path(TEMP_DIR).mkdir(parents=True, exist_ok=True)
+
+SOURCE_DIR = Path(__file__).parent.resolve()
+# endregion ############### CONSTANTs ###############################
 
 
-class FocusAutoSavePlugin(GObject.Object, Gedit.WindowActivatable):
+class FocusAutoSavePlugin(GObject.Object, Gedit.WindowActivatable, PeasGtk.Configurable):
     __gtype_name__ = "FocusAutoSavePlugin"
     window = GObject.property(type=Gedit.Window)
 
@@ -61,15 +83,78 @@ class FocusAutoSavePlugin(GObject.Object, Gedit.WindowActivatable):
             if doc.get_file().is_readonly():
                 # skip read-only files
                 continue
-            if doc.get_file().get_location() is None:
+            if doc.get_file().get_location() is None and FA_CONFIG["temp_path"] is not None:
                 # provide a default filename
                 now = datetime.datetime.now()
-                Path(dirname).mkdir(parents=True, exist_ok=True)
-                filename = str(dirname/now.strftime(f"%Y%m%d-%H%M%S-{n+1}.txt"))
+                Path(FA_CONFIG["temp_path"]).mkdir(parents=True, exist_ok=True)
+                filename = str(Path(FA_CONFIG["temp_path"])/now.strftime(f"%Y%m%d-%H%M%S-{n+1}.txt"))
                 doc.get_file().set_location(Gio.file_parse_name(filename))
+            else:
+                continue
             # save the document
             Gedit.commands_save_document(self.window, doc)
 
+    def do_create_configure_widget(self):
+        # Just return your box, PeasGtk will automatically pack it into a box and show it.
+        builder = Gtk.Builder()
+        builder.add_from_file(str(SOURCE_DIR/"focus_autosave_config.glade"))
+        builder.connect_signals(Handler(self))
+
+        window = builder.get_object("window")
+        self.untitled_savecheck =builder.get_object("untitled_savecheck")
+        self.folder = builder.get_object("folder")
+
+        if FA_CONFIG["temp_path"] is None:
+            self.folder.unselect_all()
+            self.untitled_savecheck.set_active(False)
+            self.folder.set_sensitive(False)
+        else:
+            self.untitled_savecheck.set_active(True)
+            self.folder.set_sensitive(True)
+            self.folder.set_current_folder(FA_CONFIG["temp_path"])
+
+        # region Signals' binding to the handlers ##############################
+        window.connect("destroy", Handler(self).on_window_destroy)
+        self.untitled_savecheck.connect("toggled", Handler(self).on_untitled_savecheck_toggled)
+        self.folder.connect("selection_changed", Handler(self).on_selection_changed)
+        # endregion  ###########################################################
+
+        return window
+
+
+class Handler:
+    def __init__(self, main_window):
+        self.main_window = main_window
+
+    def on_window_destroy(self, *args):
+        if ( self.main_window.untitled_savecheck.get_active() and
+            (folder:=self.main_window.folder.get_filename()) is not None ):
+                FA_CONFIG["temp_path"] = folder
+        else:
+            FA_CONFIG["temp_path"] = None
+
+        with open(COFING_FILE, mode="w", encoding="utf-8") as conf:
+            json.dump(FA_CONFIG, conf)
+
+
+    def on_selection_changed(self, file_chooser):
+        folder = file_chooser.get_filename()
+        if folder and self.main_window.untitled_savecheck.get_active():
+            FA_CONFIG["temp_path"] = str(Path(folder))
+        else:
+            FA_CONFIG["temp_path"] = None
+
+
+    def on_untitled_savecheck_toggled(self, toggle_button):
+        if toggle_button.get_active():
+            self.main_window.folder.set_sensitive(True)
+            if (FA_CONFIG["temp_path"]) is None:
+                FA_CONFIG["temp_path"] = DEFAULT_TEMP_PATH
+                self.main_window.folder.set_current_folder(FA_CONFIG["temp_path"])
+        else:
+            self.main_window.folder.unselect_all()
+            self.main_window.folder.set_sensitive(False)
+            FA_CONFIG["temp_path"] = None
 
 
 

--- a/focus_autosave.py
+++ b/focus_autosave.py
@@ -15,7 +15,7 @@ from pathlib import Path
 gi.require_version("Gtk", "3.0")
 
 # region ############### CONSTANTs #################################
-DEFAULT_TEMP_PATH = "/tmp/.gedit_unsaved"
+DEFAULT_TEMP_PATH = Path("~/.gedit_unsaved").expanduser()
 
 GEDIT_CONFIG_DIR = Path(GLib.get_user_config_dir())/"gedit"
 COFING_FILE = Path(GEDIT_CONFIG_DIR)/"focus_autosave_settings.json"
@@ -28,7 +28,7 @@ except (FileNotFoundError, json.JSONDecodeError):
     FA_CONFIG = dict(temp_path=None)
 
 if FA_CONFIG["temp_path"] is not None:
-    TEMP_DIR = Path(FA_CONFIG.get("temp_path", DEFAULT_TEMP_PATH)).expanduser()
+    TEMP_DIR = Path(FA_CONFIG["temp_path"]).expanduser()
     Path(TEMP_DIR).mkdir(parents=True, exist_ok=True)
 
 SOURCE_DIR = Path(__file__).parent.resolve()
@@ -150,7 +150,7 @@ class Handler:
             self.main_window.folder.set_sensitive(True)
             if (FA_CONFIG["temp_path"]) is None:
                 FA_CONFIG["temp_path"] = DEFAULT_TEMP_PATH
-                self.main_window.folder.set_current_folder(FA_CONFIG["temp_path"])
+                self.main_window.folder.set_current_folder(str(FA_CONFIG["temp_path"]))
         else:
             self.main_window.folder.unselect_all()
             self.main_window.folder.set_sensitive(False)

--- a/focus_autosave_config.glade
+++ b/focus_autosave_config.glade
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.40.0 -->
+<interface>
+  <requires lib="gtk+" version="3.24"/>
+  <object class="GtkAdjustment" id="adj_as">
+    <property name="upper">60000</property>
+    <property name="value">2000</property>
+    <property name="step-increment">10</property>
+    <property name="page-increment">100</property>
+  </object>
+  <object class="GtkBox" id="window">
+    <property name="visible">True</property>
+    <property name="can-focus">False</property>
+    <property name="margin-start">10</property>
+    <property name="margin-end">10</property>
+    <property name="margin-top">10</property>
+    <property name="margin-bottom">10</property>
+    <property name="orientation">vertical</property>
+    <property name="spacing">10</property>
+    <child>
+      <object class="GtkBox">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <child>
+          <object class="GtkCheckButton" id="untitled_savecheck">
+            <property name="label" translatable="yes">Save untitled files temporarily</property>
+            <property name="visible">True</property>
+            <property name="can-focus">True</property>
+            <property name="receives-default">False</property>
+            <property name="draw-indicator">True</property>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="spacing">10</property>
+            <child>
+              <object class="GtkLabel">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="label" translatable="yes">Location for saving untitled files temporarily:</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkFileChooserButton" id="folder">
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="is-focus">True</property>
+                <property name="halign">start</property>
+                <property name="action">select-folder</property>
+                <property name="title" translatable="yes"/>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">False</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </object>
+      <packing>
+        <property name="expand">False</property>
+        <property name="fill">True</property>
+        <property name="position">2</property>
+      </packing>
+    </child>
+  </object>
+</interface>

--- a/makefile
+++ b/makefile
@@ -1,7 +1,7 @@
 
 install::
 	@mkdir -p ~/.local/share/gedit/plugins
-	@cp focus{-autosave.plugin,_autosave.py} ~/.local/share/gedit/plugins -v
+	@cp focus_autosave{.py,_config.glade} focus-autosave.plugin ~/.local/share/gedit/plugins -v
 
 uninstall:
-	@rm -fv  ~/.local/share/gedit/plugins/focus{-,_}autosave.{plugin,py}
+	@rm -fv  ~/.local/share/gedit/plugins/focus{-,_}autosave{_config,}.{plugin,py,glade}


### PR DESCRIPTION
I believe it would be more appropriate to introduce a preferences window, allowing users to decide whether they want to enable auto-save for untitled files or not. Additionally, users should have the flexibility to choose their preferred save location beyond the default suggestion of `~/.gedit_unsaved/`. Instead, I propose setting the default location to `/tmp/.gedit_unsaved` to avoid cluttering the home directory with a substantial number of files over time.